### PR TITLE
feat: Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20
+# Create app directory
+WORKDIR /usr/src/app
+# Install app dependencies
+COPY package*.json ./
+RUN npm install
+# Bundle app source
+COPY . .
+EXPOSE 6969
+CMD [ "npm", "run", "start-local" ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,21 @@ Currently hosted on `nuff.gay`. To use it, simply take an avherald.com URL and r
 
 ## Running locally
 
-Run:
+### With Docker
+
+```
+$ npm run docker:build
+$ npm run docker:run
+```
+
+### With Docker Compose
+```
+$ npm run docker:compose
+```
+
+You can find the details of the docker-compose setup in `docker-compose.yml`.
+
+### With NPM
 
 ```
 $ npm i

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.7'
+services:
+  embedherlad:
+    image: nufflee/embedherald:latest
+    ports:
+      - 6969:6969

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "src/worker.ts",
   "scripts": {
     "start-local": "npx ts-node src/local.ts --transpileOnly",
-    "deploy": "npx wrangler deploy src/worker.ts"
+    "deploy": "npx wrangler deploy src/worker.ts",
+    "docker:build": "docker build . -t nufflee/embedherald",
+    "docker:run": "docker run -p 6969:6969 nufflee/embedherald"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds the required files to implement docker: 
- Dockerfile
- .dockerignore
- docker-compose.yml

Updated the npm scripts to make this easier, and included the new commands & docker run info on readme. 

Note: 
An additional PR needs to be created to automate either of the following: 
- Publish image to GitHub Packages.
- Publish image to Docker Hub.
The current implementation assumes the user first builds the package locally (as the image does not exist in a registry) 