### PR TITLE
More informative title and description

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -20,6 +20,16 @@ export async function generateHTML(articleId: string) {
 
   const potentialTitles = parsed.querySelectorAll(".headline_article");
   let title = potentialTitles[potentialTitles.length - 1].innerText;
+
+  // take the date out of the title
+  const onIndex = title.indexOf(' on ');
+  const commaIndex = title.indexOf(', ');
+  let date = '';
+  if (commaIndex > onIndex && onIndex > 0) {
+    date = title.substring(onIndex, commaIndex);
+    title = title.substring(0, onIndex) + title.substring(commaIndex);
+  }
+
   const content = parsed.querySelector("td > div > .sitetext");
   const images = content!.querySelectorAll("img");
 
@@ -29,9 +39,24 @@ export async function generateHTML(articleId: string) {
   title = title.split(":")[1].trim();
 
   let contentText = content!.childNodes
-    .map((node) => {
+    .map((node, i) => {
       if (node.nodeType === NodeType.TEXT_NODE) {
-        return node.text;
+        if (i === 0) {
+          // extract the location, which means the stuff between "was" and "when", and what happened, which begins after "when".
+          const nodeTextContent = node.text;
+          const wasIndex = nodeTextContent.indexOf(' was ');
+          const whenIndex = nodeTextContent.indexOf(' when ');
+
+          // if things go unexpectedly, abort
+          if (wasIndex >= whenIndex || wasIndex < 0) return node.text;
+
+          let location = nodeTextContent.substring(wasIndex + 5, whenIndex);
+          location = location[0].toUpperCase() + location.slice(1);
+          let happenings = nodeTextContent.substring(whenIndex + 6);
+          happenings = happenings[0].toUpperCase() + happenings.slice(1);
+
+          return `📌 ${location + date}\n\n${happenings}`;
+        } else return node.text;
       } else {
         if (node.nodeType == NodeType.ELEMENT_NODE && (node as unknown as Element).tagName === "BR") {
           return "\n";
@@ -43,7 +68,10 @@ export async function generateHTML(articleId: string) {
     .join("");
 
   // Trim content to 400 characters
-  contentText = contentText.slice(0, 400);
+  contentText = contentText.slice(0, 400).trim() + '...';
+
+  // todo: date of incident
+
 
   return `
     <head>


### PR DESCRIPTION
I used repeating patterns in the format of Avherald articles to
- shorten the title, making it fit on the screen
- put the location and date of the incident in the beginning of the description
- cut off the beginning of the article that includes irrelevant information

This feature somewhat depends on the format of Avherald articles staying unchanged. I did implement a simple check to make sure that this doesn't completely botch the embed, but this solution doesn't cover all cases.

The purpose of the pin emoji is to signify a place and time, but it might just end up being confusing. If it is ever removed, a full stop should be added to the end of the sentence.